### PR TITLE
Correct powershell syntax for a jlink argument

### DIFF
--- a/runestar-launcher.ps1
+++ b/runestar-launcher.ps1
@@ -53,7 +53,7 @@ if (!(Test-Path $jre_dir)) {
 	 --strip-debug `
 	 --compress=2 `
 	 --module-path "$temp_jdk_home\jmods" `
-	 --add-modules java.desktop,java.management,java.naming,java.sql,java.net.http `
+	 --add-modules "java.desktop,java.management,java.naming,java.sql,java.net.http" `
 	 --output "$jre_dir"
 
 	if ($LastExitCode) { exit $LastExitCode }


### PR DESCRIPTION
The commas denoted an array separator in powershell, which is not what is intended and caused jlink to return with an error